### PR TITLE
excluding non-default rulesets for RedHat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of auditd.
 
+## 0.1.2:
+
+* excluded non-default rulesets for RedHat; they use a version-specific path that I can't find any easy way to determine programatically
+
 ## 0.1.1:
 
 * added RedHat support

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer_email "ops@hw-ops.com"
 license          "Apache 2.0"
 description      "Installs/Configures auditd"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.1.0"
+version          "0.1.2"
 
 %w{redhat ubuntu}.each do |os|
   supports os

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -26,15 +26,20 @@ service "auditd" do
   action :enable
 end
 
-case node['auditd']['ruleset']
-when "capp"
-  auditd_builtins "capp"
-when "lspp"
-  auditd_builtins "lspp"
-when "nispom"
-  auditd_builtins "nispom"
-when "stig"
-  auditd_builtins "stig"
-else
+if node['platform'] == 'ubuntu'
+  case node['auditd']['ruleset']
+  when "capp"
+    auditd_builtins "capp"
+  when "lspp"
+    auditd_builtins "lspp"
+  when "nispom"
+    auditd_builtins "nispom"
+  when "stig"
+    auditd_builtins "stig"
+  else
+    auditd_ruleset "default.rules"
+  end
+else 
+  # RedHat uses version-specific paths for rule samples, we're only doing defaults for now
   auditd_ruleset "default.rules"
 end


### PR DESCRIPTION
They're using version-specific paths for their sample .rules files, which I can't programatically determine at this time.
