### PR TITLE
Adding full rules support for RHEL

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,7 +12,7 @@ platforms:
 - name: centos-6.4
   run_list:
   - recipe[yum]
-- name: centos-5.9
+- name: centos-5.10
   run_list:
   - recipe[yum]
 
@@ -24,3 +24,10 @@ suites:
 - name: rules
   run_list:
   - recipe[auditd::rules]
+
+- name: stig-rules
+  run_list:
+  - recipe[auditd::rules]
+  attributes:
+    auditd:
+      ruleset: "stig"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Attributes
 ==========
 * node['auditd']['ruleset'] - ruleset to use, either "default" (the default if
   unset) or one of the provided examples
-	* NOTE: When using this recipe on RHEL systems, you're restricted to the "default" or "cis" rulesets, as RHEL uses version-specific paths for the .rules which we can't programatically determine at this time.
 * node['auditd']['backlog'] - backlog size, default is 320 should be
 larger for busy systems
 

--- a/providers/builtins.rb
+++ b/providers/builtins.rb
@@ -18,11 +18,21 @@
 #
 
 # provider for installing audit templates provided by auditd package
+
 action :create do
-  execute "installing ruleset #{new_resource.name}" do
-    command "zcat /usr/share/doc/auditd/examples/#{new_resource.name}.rules.gz\
+  case node['platform_family']
+  when 'rhel'
+    auditd_version = %x{/sbin/aureport -v}.split(" ").last
+
+    remote_file "/etc/audit/audit.rules" do
+      source "file:///usr/share/doc/audit-#{auditd_version}/#{new_resource.name}.rules"
+      notifies :restart, 'service[auditd]'
+    end
+  else
+    execute "installing ruleset #{new_resource.name}" do
+      command "zcat /usr/share/doc/auditd/examples/#{new_resource.name}.rules.gz\
  > /etc/audit/audit.rules"
-    notifies :restart, resources( :service => "auditd" )
+      notifies :restart, 'service[auditd]'
+    end
   end
 end
-


### PR DESCRIPTION
This should add proper detection of the audit version when copying the default rules. 

I did find an oddity when testing against CentOS 6.5 where the audit package was already installed but no rules files existed. Doing `yum reinstall audit` took care of the issue and allowed for a successful run, so I'm just going to write that off as an issue with the vagrant image. On CentOS 6.4, auditd is not preinstalled. 
