### PR TITLE
Use auditctl to load new rules

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -5,29 +5,32 @@ driver:
 platforms:
 - name: ubuntu-12.04
   run_list:
-  - recipe[apt]
+    - recipe[apt]
 - name: ubuntu-10.04
   run_list:
-  - recipe[apt]
+    - recipe[apt]
+- name: centos-7.0
+  run_list:
+    - recipe[yum]
 - name: centos-6.4
   run_list:
-  - recipe[yum]
+    - recipe[yum]
 - name: centos-5.10
   run_list:
-  - recipe[yum]
+    - recipe[yum]
 
 suites:
 - name: default
   run_list:
-  - recipe[auditd]
+    - recipe[auditd]
 
 - name: rules
   run_list:
-  - recipe[auditd::rules]
+    - recipe[auditd::rules]
 
 - name: stig-rules
   run_list:
-  - recipe[auditd::rules]
+    - recipe[auditd::rules]
   attributes:
     auditd:
       ruleset: "stig"

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -34,3 +34,6 @@ suites:
   attributes:
     auditd:
       ruleset: "stig"
+  excludes:
+    - ubuntu-12.04
+    - ubuntu-10.04

--- a/providers/builtins.rb
+++ b/providers/builtins.rb
@@ -19,19 +19,33 @@
 
 # provider for installing audit templates provided by auditd package
 
+include Chef::Mixin::ShellOut
+
 action :create do
   case node['platform_family']
+  when 'gentoo'
+    version = shell_out!('portageq best_version / sys-process/audit').stdout.chomp.sub('sys-process/audit-', '')
+    data = shell_out!('bzcat', "/usr/share/doc/audit-#{version}/contrib/#{new_resource.name}.rules.bz2").stdout
   when 'rhel'
-    auditd_version = `/sbin/aureport -v`.split(' ').last
-
-    remote_file '/etc/audit/audit.rules' do
-      source "file:///usr/share/doc/audit-#{auditd_version}/#{new_resource.name}.rules"
-      notifies :restart, 'service[auditd]'
-    end
+    version = shell_out!('/sbin/aureport -v').stdout.split.last
+    data = ::File.read("/usr/share/doc/audit-#{version}/#{new_resource.name}.rules")
+  when 'fedora'
+    data = ::File.read("/usr/share/doc/audit/#{new_resource.name}.rules")
+  when 'suse'
+    data = ::File.read("/usr/share/doc/packages/audit/#{new_resource.name}.rules")
+  when 'debian'
+    require 'zlib'
+    data = Zlib::GzipReader.open("/usr/share/doc/auditd/examples/#{new_resource.name}.rules.gz", &:read)
+  when 'arch', 'slackware'
+    fail NotImplementedError, node['platform'] + ' does not install the built in rules'
   else
-    execute "installing ruleset #{new_resource.name}" do
-      command "zcat /usr/share/doc/auditd/examples/#{new_resource.name}.rules.gz > /etc/audit/audit.rules"
-      notifies :restart, 'service[auditd]'
-    end
+    fail NotImplementedError, 'cannot find the built in rules on this platform'
   end
+
+  f = file '/etc/audit/audit.rules' do
+    content data
+    notifies :run, 'execute[auditctl -R]', :immediately
+  end
+
+  new_resource.updated_by_last_action(f.updated_by_last_action?)
 end

--- a/providers/ruleset.rb
+++ b/providers/ruleset.rb
@@ -18,9 +18,12 @@
 #
 
 # provider for installing audit rules from a template
+
 action :create do
-  template '/etc/audit/audit.rules' do
+  t = template '/etc/audit/audit.rules' do
     source "#{new_resource.name}.erb"
-    notifies :restart, resources(service: 'auditd')
+    notifies :run, 'execute[auditctl -R]', :immediately
   end
+
+  new_resource.updated_by_last_action(t.updated_by_last_action?)
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,12 +18,10 @@
 #
 
 case node['platform_family']
-when 'rhel'
-  package 'audit'
-when 'fedora'
-  package 'audit'
-else
+when 'debian'
   package 'auditd'
+else
+  package 'audit'
 end
 
 service 'auditd' do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,6 +25,11 @@ else
 end
 
 service 'auditd' do
-  supports [:restart, :reload, :status]
-  action :enable
+  supports [:reload, :status]
+  action [:enable, :start]
+end
+
+execute 'auditctl -R' do
+  command 'auditctl -R /etc/audit/audit.rules'
+  action :nothing
 end


### PR DESCRIPTION
This is essential to get this cookbook working on CentOS 7. See the commit messages for details.

On discovering that none of the built in rules work on anything but RHEL or Fedora, I realised that adding support for those other platforms may have been a bit pointless but hey-ho.
