### PR TITLE
PP-1269 Override CIS template for Ubuntu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file is used to list changes made in each version of auditd.
 
+
+## 1.0.1 (2016-10-13)
+
+- Add new array attribute to hold optional additional lines to add into ERB
+- Fix issue where missing system directories on Ubuntu resulted in only half the CIS rulebase to load
+
 ## 1.0.0 (2016-09-08)
 
 - Testing updates

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The OS package provides the client side tools for working with the linux kernel 
 
 - node['auditd']['ruleset'] - ruleset to use, either "default" (the default if unset) or one of the provided examples
 - node['auditd']['backlog'] - backlog size, default is 320 should be larger for busy systems
+- node['auditd']['additional_lines'] - (array of strings) enables the addition of extra lines to the rendered ERB template that you may wish to include as well as those in the selected rulebase.
 
 # Usage
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,3 +18,4 @@
 
 default['auditd']['ruleset'] = 'default.rules'
 default['auditd']['backlog'] = 320
+default['auditd']['additional_lines'] = ['']

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache 2.0'
 description 'Installs/Configures auditd'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.0.0'
+version '1.0.1'
 
 %w(redhat ubuntu fedora centos scientific oracle).each do |os|
   supports os

--- a/templates/debian/cis.rules.erb
+++ b/templates/debian/cis.rules.erb
@@ -38,7 +38,6 @@
 -w /etc/issue -p wa -k system-locale
 -w /etc/issue.net -p wa -k system-locale
 -w /etc/hosts -p wa -k system-locale
--w /etc/sysconfig/network -p wa -k system-locale
 
 # CIS 5.2.7
 -w /etc/selinux/ -p wa -k MAC-policy
@@ -98,7 +97,6 @@
 -a always,exit -F path=/sbin/unix_chkpwd -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged
 -a always,exit -F path=/sbin/netreport -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged
 -a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged
--a always,exit -F path=/lib64/dbus-1/dbus-daemon-launch-helper -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged
 
 # CIS 5.2.18
 -e 2

--- a/templates/default/capp.rules.erb
+++ b/templates/default/capp.rules.erb
@@ -3,8 +3,8 @@
 ## system events that are audited by default, this set of rules causes
 ## audit to generate records for the auditable events specified by the
 ## Controlled Access Protection Profile (CAPP).
-## 
-## It should be noted that this set of rules identifies directories by 
+##
+## It should be noted that this set of rules identifies directories by
 ## leaving a / at the end of the path.
 ##
 ## For audit 2.0.6 and higher
@@ -12,6 +12,12 @@
 
 ## Remove any existing rules
 -D
+
+# Feel free to add below this line. See auditctl man page
+
+<% node['auditd']['additional_lines'].each do |line| %>
+<%= line %>
+<% end %>
 
 ## Increase buffer size to handle the increased number of messages.
 ## Feel free to increase this if the machine panic's
@@ -27,7 +33,7 @@
 ##
 -w /var/log/audit/ -k LOG_audit
 
-## 
+##
 ## FAU_SEL.1, FMT_MTD.1
 ## modifications to audit configuration that occur while the audit
 ## collection functions are operating; all modications to the set of
@@ -53,8 +59,8 @@
 ## files and directories covered by filesystem watches.
 
 ## Changes in ownership and permissions
-#-a always,exit -F arch=b32 -S chmod -S fchmod -S fchmodat 
-#-a always,exit -F arch=b64 -S chmod -S fchmod -S fchmodat 
+#-a always,exit -F arch=b32 -S chmod -S fchmod -S fchmodat
+#-a always,exit -F arch=b64 -S chmod -S fchmod -S fchmodat
 #-a always,exit -F arch=b32 -S chown -S fchown -S fchownat -S lchown
 #-a always,exit -F arch=b64 -S chown -S fchown -S fchownat -S lchown
 ## Enable *32 rules if you are running on i386 or s390
@@ -189,7 +195,7 @@
 -w /etc/cron.daily/ -p wa -k CFG_cron.daily
 -w /etc/cron.hourly/ -p wa -k CFG_cron.hourly
 -w /etc/cron.monthly/ -p wa -k CFG_cron.monthly
--w /etc/cron.weekly/ -p wa -k CFG_cron.weekly 
+-w /etc/cron.weekly/ -p wa -k CFG_cron.weekly
 -w /etc/crontab -p wa -k CFG_crontab
 -w /var/spool/cron/root -k CFG_crontab_root
 

--- a/templates/default/default.rules.erb
+++ b/templates/default/default.rules.erb
@@ -11,3 +11,7 @@
 -b <%= node['auditd']['backlog'] %>
 
 # Feel free to add below this line. See auditctl man page
+
+<% node['auditd']['additional_lines'].each do |line| %>
+<%= line %>
+<% end %>

--- a/templates/default/lspp.rules.erb
+++ b/templates/default/lspp.rules.erb
@@ -3,7 +3,7 @@
 ## system events that are audited by default, this set of rules causes
 ## audit to generate records for the auditable events specified by the
 ## Labeled Security Protection Profile (LSPP).
-## 
+##
 ## It should be noted that this set of rules identifies directories by
 ## leaving a / at the end of the path.
 ##
@@ -12,6 +12,12 @@
 
 ## Remove any existing rules
 -D
+
+# Feel free to add below this line. See auditctl man page
+
+<% node['auditd']['additional_lines'].each do |line| %>
+<%= line %>
+<% end %>
 
 ## Increase buffer size to handle the increased number of messages.
 ## Feel free to increase this if the machine panic's
@@ -27,7 +33,7 @@
 ##
 -w /var/log/audit/ -k LOG_audit
 
-## 
+##
 ## FAU_SEL.1, FMT_MTD.1
 ## modifications to audit configuration that occur while the audit
 ## collection functions are operating; all modications to the set of
@@ -54,8 +60,8 @@
 ## files and directories covered by filesystem watches.
 
 ## Changes in ownership and permissions
-#-a always,exit -F arch=b32 -S chmod -S fchmod -S fchmodat 
-#-a always,exit -F arch=b64 -S chmod -S fchmod -S fchmodat 
+#-a always,exit -F arch=b32 -S chmod -S fchmod -S fchmodat
+#-a always,exit -F arch=b64 -S chmod -S fchmod -S fchmodat
 #-a always,exit -F arch=b32 -S chown -S fchown -S fchownat -S lchown
 #-a always,exit -F arch=b64 -S chown -S fchown -S fchownat -S lchown
 ## Enable *32 rules if you are running on i386 or s390
@@ -152,7 +158,7 @@
 #-a always,exit -S clone2
 
 ##
-## FDP_ETC.2 
+## FDP_ETC.2
 ## Export of Labeled User Data
 ##
 ## Printing
@@ -226,7 +232,7 @@
 -w /etc/cron.daily/ -p wa -k CFG_cron.daily
 -w /etc/cron.hourly/ -p wa -k CFG_cron.hourly
 -w /etc/cron.monthly/ -p wa -k CFG_cron.monthly
--w /etc/cron.weekly/ -p wa -k CFG_cron.weekly 
+-w /etc/cron.weekly/ -p wa -k CFG_cron.weekly
 -w /etc/crontab -p wa -k CFG_crontab
 -w /var/spool/cron/root -k CFG_crontab_root
 

--- a/templates/default/nispom.rules.erb
+++ b/templates/default/nispom.rules.erb
@@ -10,6 +10,12 @@
 ## Remove any existing rules
 -D
 
+# Feel free to add below this line. See auditctl man page
+
+<% node['auditd']['additional_lines'].each do |line| %>
+<%= line %>
+<% end %>
+
 ## Increase buffer size to handle the increased number of messages.
 ## Feel free to increase this if the machine panic's
 -b 8192
@@ -76,10 +82,10 @@
 -a always,exit -F arch=b64 -S rename -S renameat -S truncate -S chmod -S setxattr -S lsetxattr -S removexattr -S lremovexattr -F exit=-EPERM -k mods
 
 ## unsuccessful deletion
--a always,exit -F arch=b32 -S rmdir -S unlink -S unlinkat -F exit=-EACCES -k delete 
--a always,exit -F arch=b64 -S rmdir -S unlink -S unlinkat -F exit=-EACCES -k delete 
--a always,exit -F arch=b32 -S rmdir -S unlink -S unlinkat -F exit=-EPERM -k delete 
--a always,exit -F arch=b64 -S rmdir -S unlink -S unlinkat -F exit=-EPERM -k delete 
+-a always,exit -F arch=b32 -S rmdir -S unlink -S unlinkat -F exit=-EACCES -k delete
+-a always,exit -F arch=b64 -S rmdir -S unlink -S unlinkat -F exit=-EACCES -k delete
+-a always,exit -F arch=b32 -S rmdir -S unlink -S unlinkat -F exit=-EPERM -k delete
+-a always,exit -F arch=b64 -S rmdir -S unlink -S unlinkat -F exit=-EPERM -k delete
 
 ## Audit 1, 1(d) Changes in user authenticators.
 ## Covered by patches to libpam, passwd, and shadow-utils

--- a/templates/default/stig.rules.erb
+++ b/templates/default/stig.rules.erb
@@ -7,6 +7,12 @@
 ## First rule - delete all
 -D
 
+# Feel free to add below this line. See auditctl man page
+
+<% node['auditd']['additional_lines'].each do |line| %>
+<%= line %>
+<% end %>
+
 ## Increase the buffers to survive stress events.
 ## Make this bigger for busy systems
 -b 8192
@@ -25,12 +31,12 @@
 ##
 ##
 ## (GEN002880: CAT II) The IAO will ensure the auditing software can
-## record the following for each audit event: 
-##- Date and time of the event 
-##- Userid that initiated the event 
-##- Type of event 
-##- Success or failure of the event 
-##- For I&A events, the origin of the request (e.g., terminal ID) 
+## record the following for each audit event:
+##- Date and time of the event
+##- Userid that initiated the event
+##- Type of event
+##- Success or failure of the event
+##- For I&A events, the origin of the request (e.g., terminal ID)
 ##- For events that introduce an object into a user’s address space, and
 ##  for object deletion events, the name of the object, and in MLS
 ##  systems, the object’s security level.
@@ -71,7 +77,7 @@
 
 ## (GEN002920: CAT III) The IAO will ensure audit files are backed up
 ## no less than weekly onto a different system than the system being
-## audited or backup media.  
+## audited or backup media.
 ##
 ## Can be done with cron script
 
@@ -110,7 +116,7 @@
 -a always,exit -F arch=b32 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
 -a always,exit -F arch=b64 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
 
-##- Unauthorized access attempts to files (unsuccessful) 
+##- Unauthorized access attempts to files (unsuccessful)
 -a always,exit -F arch=b32 -S creat -S open -S openat -S open_by_handle_at -S truncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
 -a always,exit -F arch=b32 -S creat -S open -S openat -S open_by_handle_at -S truncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
 -a always,exit -F arch=b64 -S creat -S open -S openat -S open_by_handle_at -S truncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
@@ -120,7 +126,7 @@
 ## use find /bin -type f -perm -04000 2>/dev/null and put all those files in a rule like this
 -a always,exit -F path=/bin/ping -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged
 
-##- Use of print command (unsuccessful and successful) 
+##- Use of print command (unsuccessful and successful)
 
 ##- Export to media (successful)
 ## You have to mount media before using it. You must disable all automounting
@@ -135,9 +141,9 @@
 -a always,exit -F arch=b32 -S unlink -S unlinkat -S rename -S renameat -F auid>=500 -F auid!=4294967295 -k delete
 -a always,exit -F arch=b64 -S unlink -S unlinkat -S rename -S renameat -F auid>=500 -F auid!=4294967295 -k delete
 
-##- All system administration actions 
+##- All system administration actions
 ##- All security personnel actions
-## 
+##
 ## Look for pam_tty_audit and add it to your login entry point's pam configs.
 ## If that is not found, use sudo which should be patched to record its
 ## commands to the audit system. Do not allow unrestricted root shells or
@@ -177,11 +183,11 @@
 ## Optional - admin may be abusing power by looking in user's home dir
 #-a always,exit -F dir=/home -F uid=0 -F auid>=500 -F auid!=4294967295 -C auid!=obj_uid -F key=power-abuse
 
-## Optional - log container creation  
+## Optional - log container creation
 #-a always,exit -F arch=b32 -S clone -F a0&2080505856 -k container-create
 #-a always,exit -F arch=b64 -S clone -F a0&2080505856 -k container-create
 
-## Optional - watch for containers that may change their configuration 
+## Optional - watch for containers that may change their configuration
 #-a always,exit -F arch=b32 -S setns -S unshare -k container-config
 #-a always,exit -F arch=b64 -S setns -S unshare -k container-config
 
@@ -190,4 +196,3 @@
 
 ## Make the configuration immutable - reboot is required to change audit rules
 -e 2
-

--- a/templates/ubuntu/cis.rules.erb
+++ b/templates/ubuntu/cis.rules.erb
@@ -38,7 +38,6 @@
 -w /etc/issue -p wa -k system-locale
 -w /etc/issue.net -p wa -k system-locale
 -w /etc/hosts -p wa -k system-locale
--w /etc/sysconfig/network -p wa -k system-locale
 
 # CIS 5.2.7
 -w /etc/selinux/ -p wa -k MAC-policy
@@ -98,7 +97,6 @@
 -a always,exit -F path=/sbin/unix_chkpwd -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged
 -a always,exit -F path=/sbin/netreport -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged
 -a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged
--a always,exit -F path=/lib64/dbus-1/dbus-daemon-launch-helper -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged
 
 # CIS 5.2.18
 -e 2


### PR DESCRIPTION
Add ubuntu specific template for CIS as directories such as
`/etc/sysconfig/network` do not exists which prevented the rest of the
rulebase from loading.