### PR TITLE
Fix RHEL 7

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -5,6 +5,9 @@ provisioner:
   name: chef_zero
   deprecations_as_errors: true
 
+verifier:
+  name: inspec
+
 platforms:
   - name: centos-6.8
   - name: centos-7.3
@@ -20,6 +23,9 @@ suites:
 - name: default
   run_list:
   - recipe[auditd::rules]
+  verifier:
+    inspec_tests:
+      - test/integration/default
 
 - name: stig-rules
   run_list:
@@ -27,6 +33,9 @@ suites:
   attributes:
     auditd:
       ruleset: "stig"
+  verifier:
+    inspec_tests:
+      - test/integration/stig
 
 - name: capp-rules
   run_list:
@@ -34,3 +43,6 @@ suites:
   attributes:
     auditd:
       ruleset: "capp"
+  verifier:
+    inspec_tests:
+      - test/integration/capp

--- a/libraries/auditd_helper.rb
+++ b/libraries/auditd_helper.rb
@@ -25,5 +25,10 @@ module AuditD
         'auditd'
       end
     end
+
+    def auditd_rulefile(ruleset = 'audit.rules')
+      return ::File.join('/etc/audit/rules.d/', ruleset) if platform_family?('rhel') && node['platform_version'].to_i >= 7
+      '/etc/audit/audit.rules'
+    end
   end
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,6 +22,7 @@ extend AuditD::Helper
 package auditd_package_name_for(node['platform_family'])
 
 service 'auditd' do
+  restart_command '/usr/libexec/initscripts/legacy-actions/auditd/restart' if platform_family?('rhel') && node['init_package'] == 'systemd'
   supports [:start, :stop, :restart, :reload, :status]
   action :enable
 end

--- a/resources/builtins.rb
+++ b/resources/builtins.rb
@@ -20,11 +20,13 @@
 property :name, String, name_attribute: true
 
 action :create do
+  extend AuditD::Helper
+
   case node['platform_family']
   when 'rhel', 'fedora'
     # auditd_version = `/sbin/aureport -v`.split(' ').last
 
-    template '/etc/audit/audit.rules' do
+    template auditd_rulefile do
       source "#{new_resource.name}.rules.erb"
       notifies :restart, 'service[auditd]'
     end

--- a/resources/ruleset.rb
+++ b/resources/ruleset.rb
@@ -21,7 +21,9 @@ property :name, String, name_attribute: true
 property :cookbook, String
 
 action :create do
-  template '/etc/audit/audit.rules' do
+  extend AuditD::Helper
+
+  template auditd_rulefile(new_resource.name) do
     source "#{new_resource.name}.erb"
     cookbook new_resource.cookbook if new_resource.cookbook
     notifies :restart, 'service[auditd]'

--- a/test/integration/capp/run_spec.rb
+++ b/test/integration/capp/run_spec.rb
@@ -1,0 +1,16 @@
+# Encoding: UTF-8
+# AuditD CAPP - Smoke Test
+
+# Service
+describe service('auditd') do
+  it { should be_installed }
+  it { should be_enabled }
+  it { should be_running }
+end
+
+# => Audit Rules should have some Content
+describe file('/etc/audit/audit.rules') do
+  it { should be_file }
+  # => This could probably be made better...
+  its('content') { should match(%r{-w /etc/passwd -p wa -k CFG_passwd}) }
+end

--- a/test/integration/default/run_spec.rb
+++ b/test/integration/default/run_spec.rb
@@ -1,0 +1,14 @@
+# Encoding: UTF-8
+# AuditD - Smoke Test
+
+# Service
+describe service('auditd') do
+  it { should be_installed }
+  it { should be_enabled }
+  it { should be_running }
+end
+
+# => Audit Rules File should Exist
+describe file('/etc/audit/audit.rules') do
+  it { should be_file }
+end

--- a/test/integration/stig/run_spec.rb
+++ b/test/integration/stig/run_spec.rb
@@ -1,0 +1,16 @@
+# Encoding: UTF-8
+# AuditD STIG - Smoke Test
+
+# Service
+describe service('auditd') do
+  it { should be_installed }
+  it { should be_enabled }
+  it { should be_running }
+end
+
+# => Audit Rules should have some Content
+describe file('/etc/audit/audit.rules') do
+  it { should be_file }
+  # => This could probably be made better...
+  its('content') { should match(%r{/etc/sudoers -p wa -k actions}) }
+end


### PR DESCRIPTION
- RHEL audit rules should be dropped in `/etc/audit/rules.d/`
- On RHEL under systemd, you need to call a helper script to get the expected restart behavior
- Add basic Inspec tests

This should address #30

## Background
`augenrules` is enabled by default, which builds `/etc/audit/audit.rules` with rules from `/etc/audit/rules.d/`

Also, I tried simply swapping to `:reload` for RHEL, but you need a restart to make this stuff work; `:reload` did not seem to trigger `/etc/audit/audit.rules` generation.  It seems within in the past two years or so, the ability to restart auditd using systemctl was disabled.  2-3 years ago I had a branch of this cookbook that only needed a rulefile location swap to function; that is no longer the case.

Finally, I threw some crappy inspec tests in here to smoke test the content of `/etc/audit/audit.rules`.  A successful Chef run can be misleading when the ruleset is dynamically generated -- Years ago I was running this for a month or so before I realized all the rules weren't active.

Final Note -- I don't think you can test this with Dokken -- I tried, and `auditd` is just all kinds of FUBAR in Docker.