### PR TITLE
Update CIS rules for RHEL/CentOS 7 v2.2.0 benchmarks

### DIFF
--- a/templates/cis.rules.erb
+++ b/templates/cis.rules.erb
@@ -15,42 +15,44 @@
 
 # CIS Benchmark Adjustments
 
-# CIS 5.2.4
+# CIS 4.1.4
 -a always,exit -F arch=b64 -S adjtimex -S settimeofday -k time-change
 -a always,exit -F arch=b32 -S adjtimex -S settimeofday -S stime -k time-change
 -a always,exit -F arch=b64 -S clock_settime -k time-change
 -a always,exit -F arch=b32 -S clock_settime -k time-change
 -w /etc/localtime -p wa -k time-change
 
-# CIS 5.2.5
+# CIS 4.1.5
 -w /etc/group -p wa -k identity
 -w /etc/passwd -p wa -k identity
 -w /etc/gshadow -p wa -k identity
 -w /etc/shadow -p wa -k identity
 -w /etc/security/opasswd -p wa -k identity
 
-# CIS 5.2.6
+# CIS 4.1.6
 -a always,exit -F arch=b64 -S sethostname -S setdomainname -k system-locale
 -a always,exit -F arch=b32 -S sethostname -S setdomainname -k system-locale
 -w /etc/issue -p wa -k system-locale
 -w /etc/issue.net -p wa -k system-locale
 -w /etc/hosts -p wa -k system-locale
 -w /etc/sysconfig/network -p wa -k system-locale
+-w /etc/sysconfig/network-scripts/ -p wa -k system-locale
 
-# CIS 5.2.7
+# CIS 4.1.7
 -w /etc/selinux/ -p wa -k MAC-policy
+-w /usr/share/selinux/ -p wa -k MAC-policy
 
-# CIS 5.2.8
+# CIS 4.1.8
 -w /var/log/faillog -p wa -k logins
 -w /var/log/lastlog -p wa -k logins
 #-w /var/log/tallylog -p -wa -k logins
 
-# CIS 5.2.9
+# CIS 4.1.9
 -w /var/run/utmp -p wa -k session
 -w /var/log/wtmp -p wa -k session
 -w /var/log/btmp -p wa -k session
 
-# CIS 5.2.10
+# CIS 4.1.10
 -a always,exit -F arch=b64 -S chmod -S fchmod -S fchmodat -F auid>=500 -F auid!=4294967295 -k perm_mod
 -a always,exit -F arch=b32 -S chmod -S fchmod -S fchmodat -F auid>=500 -F auid!=4294967295 -k perm_mod
 -a always,exit -F arch=b64 -S chown -S fchown -S fchownat -S lchown -F auid>=500 -F auid!=4294967295 -k perm_mod
@@ -58,34 +60,35 @@
 -a always,exit -F arch=b64 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
 -a always,exit -F arch=b32 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
 
-# CIS 5.2.11
+# CIS 4.1.11
 -a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
 -a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
 -a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
 -a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
 
-# CIS 5.2.13
+# CIS 4.1.13
 -a always,exit -F arch=b64 -S mount -F auid>=500 -F auid!=4294967295 -k mounts
 -a always,exit -F arch=b32 -S mount -F auid>=500 -F auid!=4294967295 -k mounts
 
-# CIS 5.2.14
--a always,exit -F arch=b64 -S unlink -S unlinkat -S rename -S renameat -F auid>=500 -F auid!=4294967295 -k delete
--a always,exit -F arch=b32 -S unlink -S unlinkat -S rename -S renameat -F auid>=500 -F auid!=4294967295 -k delete
+# CIS 4.1.14
+-a always,exit -F arch=b64 -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 -F auid!=4294967295 -k delete
+-a always,exit -F arch=b32 -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 -F auid!=4294967295 -k delete
 
-# CIS 5.2.15
+# CIS 4.1.15
 -w /etc/sudoers -p wa -k scope
+-w /etc/sudoers.d/ -p wa -k scope
 
-# CIS 5.2.16
+# CIS 4.1.16
 -w /var/log/sudo.log -p wa -k actions
 
-# CIS 5.2.17
+# CIS 4.1.17
 -w /sbin/insmod -p x -k modules
 -w /sbin/rmmod -p x -k modules
 -w /sbin/modprobe -p x -k modules
 #-a always,exit arch=b32 -S init_module -S delete_module -k modules
-#-a always,exit arch=b64 -S init_module -S delete_module -k modules
+-a always,exit arch=b64 -S init_module -S delete_module -k modules
 
-# CIS 5.2.12
+# CIS 4.1.12
 -a always,exit -F path=/bin/cgexec -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged
 -a always,exit -F path=/bin/mount -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged
 -a always,exit -F path=/bin/umount -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged
@@ -97,5 +100,5 @@
 -a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged
 -a always,exit -F path=/lib64/dbus-1/dbus-daemon-launch-helper -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged
 
-# CIS 5.2.18
+# CIS 4.1.18
 -e 2


### PR DESCRIPTION
Update the rules and their numbering to match the current CIS benchmark (v2.2.0 for both CentOS and RHEL 7)

Signed-off-by: James Stocks <jstocks@chef.io>