### PR TITLE
Fix support for Debian 9+ / Ubuntu 18.04+

### DIFF
--- a/libraries/auditd_helper.rb
+++ b/libraries/auditd_helper.rb
@@ -27,8 +27,11 @@ module AuditD
     end
 
     def auditd_rulefile(ruleset = 'audit.rules')
-      return ::File.join('/etc/audit/rules.d/', ruleset) if platform_family?('rhel') && node['platform_version'].to_i >= 7
-      '/etc/audit/audit.rules'
+      if platform_family?('rhel') && node['platform_version'].to_i >= 7 || platform?('ubuntu') && node['platform_version'].to_f >= 18.04 || platform?('debian') && node['platform_version'].to_i >= 9
+        ::File.join('/etc/audit/rules.d/', ruleset)
+      else
+        '/etc/audit/audit.rules'
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #35. On Debian 9+ / Ubuntu 18.04+ the config is generated from snippets in `/etc/audit/rules.d`. This is the same fix that went in for RHEL7. 

Signed-off-by: Eric Heydrick <eheydrick@gmail.com>