### PR TITLE
Remove Chef 11/early 12 compatibility in metadata

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -12,4 +12,4 @@ end
 
 source_url 'https://github.com/chef-cookbooks/auditd'
 issues_url 'https://github.com/chef-cookbooks/auditd/issues'
-chef_version '>= 12.7' if respond_to?(:chef_version)
+chef_version '>= 12.7'


### PR DESCRIPTION
There's no need to gate this metadata at this point.

Signed-off-by: Tim Smith <tsmith@chef.io>