### PR TITLE
Fix RHEL

### DIFF
--- a/libraries/auditd_helper.rb
+++ b/libraries/auditd_helper.rb
@@ -33,14 +33,5 @@ module AuditD
         '/etc/audit/audit.rules'
       end
     end
-
-    def auditd_conffile(conf_file = 'audit.conf')
-      if platform_family?('rhel') && node['platform_version'].to_i >= 6
-        ::File.join('/etc/audit/', conf_file)
-      else
-        '/etc/audit/auditd.conf'
-      end
-    end
-
   end
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,7 +22,10 @@ extend AuditD::Helper
 package auditd_package_name_for(node['platform_family'])
 
 service 'auditd' do
-  restart_command '/usr/libexec/initscripts/legacy-actions/auditd/restart' if platform_family?('rhel') && node['init_package'] == 'systemd'
+  if platform_family?('rhel') && node['init_package'] == 'systemd'
+    reload_command '/usr/libexec/initscripts/legacy-actions/auditd/reload'
+    restart_command '/usr/libexec/initscripts/legacy-actions/auditd/restart'
+  end
   supports [:start, :stop, :restart, :reload, :status]
   action :enable
 end

--- a/resources/conf_file.rb
+++ b/resources/conf_file.rb
@@ -20,9 +20,7 @@
 property :cookbook, String
 
 action :create do
-  extend AuditD::Helper
-
-  template auditd_conffile(new_resource.name) do
+  template '/etc/audit/auditd.conf' do
     source "#{new_resource.name}.conf.erb"
     cookbook new_resource.cookbook if new_resource.cookbook
     notifies :reload, 'service[auditd]'

--- a/templates/cis.rules.erb
+++ b/templates/cis.rules.erb
@@ -107,7 +107,11 @@
 -a always,exit -F path=/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
 -a always,exit -F path=/sbin/netreport -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
 -a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
--a always,exit -F path=/lib64/dbus-1/dbus-daemon-launch-helper -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
+<% dbus = [
+            '/usr/libexec/dbus-1/dbus-daemon-launch-helper',
+            '/lib64/dbus-1/dbus-daemon-launch-helper'
+          ].find { |f| ::File.exist?(f) } %>
+-a always,exit -F path=<%= dbus %> -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged
 
 # CIS 4.1.18
 -e 2

--- a/test/integration/cis/run_spec.rb
+++ b/test/integration/cis/run_spec.rb
@@ -33,3 +33,8 @@ describe file('/etc/audit/auditd.conf') do
   its('mode') { should cmp '0640' }
   its('content') { should match(%r{\# This file is managed using Chef.}) }
 end
+
+# => Ensure no errors loading the Auditd Configuration
+describe command('/sbin/augenrules --load') do
+  its('exit_status') { should eq 0 }
+end


### PR DESCRIPTION
### Fixes:
* Remove incorrect path to `auditd` configuration, it should never change
* Broken path for `dbus-daemon-launch-helper`
* RHEL SystemD unit still doesn't have logic in it for anything other than start/stop.  It uses helpers
