### PR TITLE
Fix auditd reloads on Ubuntu 20.04

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -33,6 +33,10 @@ service 'auditd' do
     reload_command '/usr/sbin/service auditd reload'
     restart_command '/usr/sbin/service auditd restart'
   end
+  if platform_family?('debian') && node['init_package'] == 'systemd' && node['platform_version'] >= '20.04'
+    reload_command '/usr/sbin/service auditd reload'
+    restart_command '/usr/sbin/service auditd restart'
+  end
   supports [:start, :stop, :restart, :reload, :status]
   action :enable
 end


### PR DESCRIPTION
Signed-off-by: Nelson Tang <nelson.tang@apperio.com>

<!--- Provide a short summary of your changes in the Title above -->

### Description
Use the `service` command for restart and reloads if platform is Ubuntu 20.04 or higher

### Issues Resolved
https://github.com/chef-cookbooks/auditd/issues/69

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>