### PR TITLE
Add support for Amazon Linux 2

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -33,6 +33,9 @@ service 'auditd' do
     reload_command '/usr/sbin/service auditd reload'
     restart_command '/usr/sbin/service auditd restart'
   end
+  if platform_family?('amazon') && node['init_package'] == 'systemd'
+    restart_command '/usr/libexec/initscripts/legacy-actions/auditd/restart'
+  end
   supports [:start, :stop, :restart, :reload, :status]
   action :enable
 end


### PR DESCRIPTION
### Description
Adds support for restarting auditd on Amazon Linux 2

### Issues Resolved
<!--- List any existing issues this PR resolves -->

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>